### PR TITLE
Handle optional Prisma client

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,9 +1,21 @@
-import { PrismaClient } from '@prisma/client'
+// Prisma is optional during build to avoid Next.js compilation errors on
+// environments where `@prisma/client` isn't installed. We attempt to require
+// it at runtime and fall back to `undefined` when the package is missing.
 
-const globalForPrisma = globalThis as unknown as {
-  prisma: PrismaClient | undefined
+let prisma: any
+
+if (typeof window === 'undefined') {
+  try {
+    const { PrismaClient } = require('@prisma/client')
+    const globalForPrisma = globalThis as { prisma?: any }
+    prisma = globalForPrisma.prisma ?? new PrismaClient()
+
+    if (process.env.NODE_ENV !== 'production') {
+      globalForPrisma.prisma = prisma
+    }
+  } catch {
+    prisma = undefined
+  }
 }
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient()
-
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+export { prisma }


### PR DESCRIPTION
## Summary
- avoid build errors when `@prisma/client` is missing by requiring it at runtime only

## Testing
- `npm run build` *(fails: Failed to fetch font `Inter`)*
- `npm run lint` *(interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689188a0e31483338091f47e022cc9d6