### PR TITLE
Handle optional Prisma client

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,9 +1,24 @@
-import { PrismaClient } from '@prisma/client'
+// Prisma is optional during build to avoid Next.js compilation errors on
+// environments where `@prisma/client` isn't installed. We attempt to require
+// it at runtime and fall back to `undefined` when the package is missing.
 
-const globalForPrisma = globalThis as unknown as {
-  prisma: PrismaClient | undefined
+let prisma: any
+
+if (typeof window === 'undefined') {
+  try {
+    const { PrismaClient } = require('@prisma/client')
+    const globalForPrisma = globalThis as { prisma?: any }
+    prisma = globalForPrisma.prisma ?? new PrismaClient()
+
+    if (process.env.NODE_ENV !== 'production') {
+      globalForPrisma.prisma = prisma
+    }
+  } catch (err: any) {
+    if (err?.code !== 'MODULE_NOT_FOUND') {
+      throw err
+    }
+    prisma = undefined
+  }
 }
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient()
-
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+export { prisma }

--- a/next.config.js
+++ b/next.config.js
@@ -1,12 +1,7 @@
-const path = require('path');
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   distDir: process.env.NEXT_DIST_DIR || '.next',
   output: process.env.NEXT_OUTPUT_MODE,
-  experimental: {
-    outputFileTracingRoot: path.join(__dirname, '../'),
-  },
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
## Summary
- avoid build errors when `@prisma/client` is missing by requiring it at runtime only
- rethrow unexpected errors so only missing `@prisma/client` is suppressed
- rely on Next.js default tracing root to avoid missing `routes-manifest.json` during Vercel builds

## Testing
- `NEXT_FONT_FORCE_LOCAL=1 npm run build` *(fails: Error [NextFontError] Failed to fetch font `Inter`)*
- `npm run lint` *(prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689188a0e31483338091f47e022cc9d6