### PR TITLE
Update site address and home page title

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -112,7 +112,9 @@ export default function ContactPage() {
                 <h3 className="text-lg font-semibold mb-2">Practice Location</h3>
                 <p className="text-gray-600 text-sm">
                   Lehigh Valley Wellness<br />
-                  Lehigh Valley, PA
+                  6081 Hamilton Blvd, Suite 600<br />
+                  Allentown, PA 18106<br />
+                  (484) 357‑1916
                 </p>
               </CardContent>
             </Card>
@@ -282,7 +284,11 @@ export default function ContactPage() {
                   <div className="space-y-2">
                     <div className="flex items-center gap-2">
                       <MapPin className="h-4 w-4 text-gray-400" />
-                      <span className="text-gray-600">Lehigh Valley, Pennsylvania</span>
+                      <span className="text-gray-600">6081 Hamilton Blvd, Suite 600, Allentown, PA 18106</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Phone className="h-4 w-4 text-gray-400" />
+                      <span className="text-gray-600">(484) 357‑1916</span>
                     </div>
                     <div className="flex items-center gap-2">
                       <Globe className="h-4 w-4 text-gray-400" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,9 @@ import PatientTestimonials from '@/components/patient-testimonials'
 import CallToAction from '@/components/call-to-action'
 
 export const metadata: Metadata = {
-  title: 'Home',
+  title: {
+    absolute: 'tephen McCarthy, PA-C | Psychiatry & Addiction Medicine | Lehigh Valley',
+  },
   description: 'Stephen McCarthy PA-C - Experienced physician assistant and clinical director at Lehigh Valley Wellness, specializing in psychiatry, mental health, and comprehensive patient care.',
 }
 

--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -14,7 +14,7 @@ const patientTestimonials = [
   {
     id: 1,
     name: "Sarah M.",
-    location: "Lehigh Valley, PA",
+    location: "Allentown, PA",
     rating: 5,
     testimonial: "Stephen McCarthy PA-C provided exceptional care during a very difficult time in my life. His compassionate approach and thorough understanding of mental health issues made all the difference in my recovery journey.",
     category: "Patient Care"

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -68,7 +68,11 @@ export default function Footer() {
             <div className="space-y-3">
               <div className="flex items-center gap-2">
                 <MapPin className="h-4 w-4 text-blue-400" />
-                <span className="text-gray-400 text-sm">Lehigh Valley, PA</span>
+                <span className="text-gray-400 text-sm">6081 Hamilton Blvd, Suite 600, Allentown, PA 18106</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Phone className="h-4 w-4 text-blue-400" />
+                <span className="text-gray-400 text-sm">(484) 357‑1916</span>
               </div>
               <div className="flex items-center gap-2">
                 <Mail className="h-4 w-4 text-blue-400" />

--- a/components/patient-testimonials.tsx
+++ b/components/patient-testimonials.tsx
@@ -12,7 +12,7 @@ const testimonials = [
   {
     id: 1,
     name: "Sarah M.",
-    location: "Lehigh Valley, PA",
+    location: "Allentown, PA",
     rating: 5,
     testimonial: "Stephen McCarthy PA-C provided exceptional care during a very difficult time in my life. His compassionate approach and thorough understanding of mental health issues made all the difference in my recovery journey.",
     category: "Mental Health Care"

--- a/components/seo/person-json-ld.tsx
+++ b/components/seo/person-json-ld.tsx
@@ -7,6 +7,7 @@ export function PersonJsonLd() {
     "jobTitle": "Physician Assistant",
     "description": "Experienced physician assistant and clinical director specializing in psychiatry, mental health, and comprehensive patient care in the Lehigh Valley region.",
     "url": "https://stephenmccarthypa.com",
+    "telephone": "(484) 357‑1916",
     "sameAs": [
       "https://www.linkedin.com/in/stephenmccarthypa",
       "https://twitter.com/stephenmccarthypa"
@@ -16,10 +17,13 @@ export function PersonJsonLd() {
       "name": "Lehigh Valley Wellness",
       "address": {
         "@type": "PostalAddress",
-        "addressLocality": "Lehigh Valley",
+        "streetAddress": "6081 Hamilton Blvd, Suite 600",
+        "addressLocality": "Allentown",
         "addressRegion": "PA",
+        "postalCode": "18106",
         "addressCountry": "US"
-      }
+      },
+      "telephone": "(484) 357‑1916"
     },
     "hasCredential": [
       {


### PR DESCRIPTION
## Summary
- update homepage metadata title to "tephen McCarthy, PA-C | Psychiatry & Addiction Medicine | Lehigh Valley"
- replace practice contact info with 6081 Hamilton Blvd, Suite 600, Allentown, PA 18106 and phone (484) 357‑1916
- add updated address and phone to schema.org Person JSON-LD data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interrupted: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d5d55f38c833395d61b636709959e