### PR TITLE
Fix portrait image sizing and add editorial graphics (clinical reasoning + evidence map)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -357,6 +357,7 @@ h3 {
 
 .portrait-frame img {
   width: 100%;
+  height: auto;
   aspect-ratio: 0.875;
   object-fit: cover;
 }
@@ -603,8 +604,47 @@ h3 {
 
 .about-image img {
   width: 100%;
+  height: auto;
   aspect-ratio: 0.875;
   object-fit: cover;
+}
+
+.reasoning-graphic-section {
+  overflow: hidden;
+  background: #eef3f4;
+}
+
+.reasoning-graphic-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.78fr) minmax(380px, 1fr);
+  align-items: center;
+  gap: clamp(2.5rem, 7vw, 7rem);
+}
+
+.reasoning-graphic-copy p:not(.eyebrow) {
+  max-width: 590px;
+  color: var(--ink-soft);
+  font-size: 1.08rem;
+}
+
+.reasoning-graphic {
+  width: 100%;
+  height: auto;
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+}
+
+.featured-article-card {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.75fr) minmax(0, 1fr);
+  gap: clamp(1.5rem, 4vw, 4rem);
+  align-items: center;
+}
+
+.article-card-graphic {
+  width: 100%;
+  height: auto;
+  border-radius: 18px;
 }
 
 .prose {
@@ -1205,6 +1245,8 @@ h3 {
 
   .hero-grid,
   .feature-grid,
+  .reasoning-graphic-grid,
+  .featured-article-card,
   .quote-wrap,
   .about-grid,
   .split-callout,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -113,6 +113,30 @@ export default function HomePage() {
         </div>
       </section>
 
+      <section className="section-pad reasoning-graphic-section" aria-labelledby="reasoning-graphic-title">
+        <div className="shell reasoning-graphic-grid">
+          <div className="reasoning-graphic-copy">
+            <p className="eyebrow">A practical visual guide</p>
+            <h2 id="reasoning-graphic-title">Three jobs, not one shortcut.</h2>
+            <p>
+              Good clinical language starts by recording what is present. A category may then help organize that record,
+              while explanation remains a separate question for evidence to answer.
+            </p>
+            <Link className="text-link" href="/writing/audhd-psychiatric-ontology">
+              See the distinction in the essay <span aria-hidden="true">→</span>
+            </Link>
+          </div>
+          <Image
+            className="reasoning-graphic"
+            src="/clinical-reasoning.svg"
+            alt="Diagram showing observation, classification, and explanation as separate stages of clinical reasoning"
+            width={960}
+            height={620}
+            sizes="(max-width: 860px) 100vw, 48vw"
+          />
+        </div>
+      </section>
+
       <section className="section-pad principles-section">
         <div className="shell">
           <div className="section-heading">

--- a/app/writing/page.tsx
+++ b/app/writing/page.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image"
 import Link from "next/link"
 import Breadcrumbs from "@/components/breadcrumbs"
 import { createPageMetadata } from "@/lib/site-metadata"
@@ -26,29 +27,39 @@ export default function WritingPage() {
       <section className="section-pad">
         <div className="shell writing-list">
           <article className="article-card featured-article-card">
-            <div className="article-meta">
-              <span>Psychiatric ontology</span>
-              <time dateTime="2026-07-19">July 19, 2026</time>
-              <span>14 minute read</span>
-            </div>
-            <h2>
-              <Link href="/writing/audhd-psychiatric-ontology">
-                AuDHD, psychiatric ontology, and the difference between naming and explaining
+            <Image
+              className="article-card-graphic"
+              src="/evidence-map.svg"
+              alt="Diagram connecting observed facts, source records, classification, and independent evidence to a clinical question"
+              width={960}
+              height={620}
+              sizes="(max-width: 860px) 100vw, 42vw"
+            />
+            <div className="article-card-content">
+              <div className="article-meta">
+                <span>Psychiatric ontology</span>
+                <time dateTime="2026-07-19">July 19, 2026</time>
+                <span>14 minute read</span>
+              </div>
+              <h2>
+                <Link href="/writing/audhd-psychiatric-ontology">
+                  AuDHD, psychiatric ontology, and the difference between naming and explaining
+                </Link>
+              </h2>
+              <p>
+                AuDHD can be useful shorthand for the co occurrence of autism and ADHD. It does not, by itself, establish a third disease entity or a causal mechanism.
+                The article develops a broader argument: a diagnosis may classify a symptom pattern, but the label alone cannot explain the symptoms used to create it.
+              </p>
+              <div className="tag-row" aria-label="Topics">
+                <span>AuDHD</span>
+                <span>Diagnosis</span>
+                <span>Reification</span>
+                <span>Clinical reasoning</span>
+              </div>
+              <Link className="text-link" href="/writing/audhd-psychiatric-ontology">
+                Read the essay <span aria-hidden="true">→</span>
               </Link>
-            </h2>
-            <p>
-              AuDHD can be useful shorthand for the co occurrence of autism and ADHD. It does not, by itself, establish a third disease entity or a causal mechanism.
-              The article develops a broader argument: a diagnosis may classify a symptom pattern, but the label alone cannot explain the symptoms used to create it.
-            </p>
-            <div className="tag-row" aria-label="Topics">
-              <span>AuDHD</span>
-              <span>Diagnosis</span>
-              <span>Reification</span>
-              <span>Clinical reasoning</span>
             </div>
-            <Link className="text-link" href="/writing/audhd-psychiatric-ontology">
-              Read the essay <span aria-hidden="true">→</span>
-            </Link>
           </article>
         </div>
       </section>

--- a/public/clinical-reasoning.svg
+++ b/public/clinical-reasoning.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 620" role="img" aria-labelledby="title desc">
+  <title id="title">Clinical reasoning from observation to explanation</title>
+  <desc id="desc">An editorial diagram with three connected stages: observe, classify, and explain.</desc>
+  <rect width="960" height="620" rx="42" fill="#12202b"/>
+  <circle cx="810" cy="112" r="174" fill="#27647a" opacity=".35"/>
+  <circle cx="100" cy="590" r="178" fill="#b95f35" opacity=".28"/>
+  <path d="M110 162H850" stroke="#f5f1e8" stroke-opacity=".28" stroke-width="2"/>
+  <text x="110" y="112" fill="#dd9a72" font-family="Arial, sans-serif" font-size="22" font-weight="700" letter-spacing="4">CLINICAL REASONING</text>
+  <text x="110" y="420" fill="#f5f1e8" font-family="Georgia, serif" font-size="52">Keep the levels distinct.</text>
+  <g fill="none" stroke="#f5f1e8" stroke-width="3">
+    <circle cx="204" cy="270" r="54"/>
+    <circle cx="480" cy="270" r="54"/>
+    <circle cx="756" cy="270" r="54"/>
+    <path d="M262 270h150m28 0h150" stroke-opacity=".55"/>
+    <path d="m394 258 18 12-18 12m270-24 18 12-18 12"/>
+  </g>
+  <g fill="#f5f1e8" font-family="Arial, sans-serif" text-anchor="middle">
+    <text x="204" y="278" font-size="21" font-weight="700">Observe</text>
+    <text x="480" y="278" font-size="21" font-weight="700">Classify</text>
+    <text x="756" y="278" font-size="21" font-weight="700">Explain</text>
+    <text x="204" y="350" font-size="17" fill-opacity=".72">what is happening?</text>
+    <text x="480" y="350" font-size="17" fill-opacity=".72">what pattern fits?</text>
+    <text x="756" y="350" font-size="17" fill-opacity=".72">what caused it?</text>
+  </g>
+  <text x="110" y="468" fill="#f5f1e8" fill-opacity=".7" font-family="Arial, sans-serif" font-size="19">A label can organize evidence without supplying a mechanism.</text>
+</svg>

--- a/public/evidence-map.svg
+++ b/public/evidence-map.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 620" role="img" aria-labelledby="title desc">
+  <title id="title">Evidence map</title>
+  <desc id="desc">An abstract diagram of source notes connected to a central clinical question.</desc>
+  <rect width="960" height="620" rx="42" fill="#edf0e9"/>
+  <path d="M0 482c173-101 282-12 414-92 151-91 314-69 546-181v411H0z" fill="#d6e2d3"/>
+  <g stroke="#6f826d" stroke-width="3" fill="none" stroke-linecap="round">
+    <path d="M231 189 456 294M728 190 504 294M237 462 455 345M730 452 506 344"/>
+  </g>
+  <g fill="#fff" stroke="#6f826d" stroke-width="3">
+    <rect x="121" y="124" width="220" height="130" rx="20"/>
+    <rect x="618" y="124" width="220" height="130" rx="20"/>
+    <rect x="121" y="397" width="220" height="130" rx="20"/>
+    <rect x="618" y="397" width="220" height="130" rx="20"/>
+    <circle cx="480" cy="320" r="78" fill="#12202b" stroke="#12202b"/>
+  </g>
+  <g font-family="Arial, sans-serif" text-anchor="middle">
+    <text x="231" y="174" fill="#344550" font-size="19" font-weight="700">Observed facts</text>
+    <text x="231" y="209" fill="#65727a" font-size="16">timing · context · impact</text>
+    <text x="728" y="174" fill="#344550" font-size="19" font-weight="700">Source records</text>
+    <text x="728" y="209" fill="#65727a" font-size="16">studies · notes · standards</text>
+    <text x="231" y="447" fill="#344550" font-size="19" font-weight="700">Classification</text>
+    <text x="231" y="482" fill="#65727a" font-size="16">useful category?</text>
+    <text x="728" y="447" fill="#344550" font-size="19" font-weight="700">Independent evidence</text>
+    <text x="728" y="482" fill="#65727a" font-size="16">supports a mechanism?</text>
+    <text x="480" y="308" fill="#f5f1e8" font-size="19" font-weight="700">Clinical</text>
+    <text x="480" y="335" fill="#f5f1e8" font-size="19" font-weight="700">question</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Ensure portrait images keep intrinsic heights and preserve intended crops across responsive layouts. 
- Improve the site’s explanatory visuals by adding editorial graphics that clarify the distinction between observation, classification, and explanation. 

### Description
- Fixed portrait and about-image behavior by making responsive images intrinsic with `height: auto` in `app/globals.css` so cropping via `object-fit` remains consistent. 
- Added a purpose-built `public/clinical-reasoning.svg` and integrated it into the home page via `app/page.tsx` with a responsive two-column layout and supporting styles in `app/globals.css`. 
- Added an `public/evidence-map.svg` and placed it in the Writing feature card via `app/writing/page.tsx`, adjusting markup and CSS for a responsive article-card layout. 
- Updated layout and utility styles in `app/globals.css` (new `.reasoning-graphic-*`, `.featured-article-card`, and `.article-card-graphic` rules) to support the new graphics and responsive behavior. 

### Testing
- Ran `npm run typecheck` and it completed successfully. 
- Ran `npm run build` and the Next.js production build completed successfully. 
- Verified the running dev server and asset endpoints returned HTTP 200 for `/`, `/writing`, `/clinical-reasoning.svg`, and `/evidence-map.svg` via `curl`. 
- Attempted a Playwright screenshot, but the environment blocked downloading Playwright from the npm registry (HTTP 403), so automated screenshot capture did not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5da4dde754832eaf25ac6a43b0ab38)