### PR TITLE
Integrate mental-health-theology briefing across site

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,6 @@ See `TEST_REPORT.md` for the completed build, route, content, structured data, a
 * `/professional-record`
 * `/writing`
 * `/writing/audhd-psychiatric-ontology`
+* `/briefing/mental-health-theology`
 * `/profiles-and-sources`
 * `/contact`

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -10,8 +10,15 @@ export async function GET() {
     <link>${base}/writing</link>
     <description>Essays on psychiatric ontology, diagnostic language, and clinical reasoning.</description>
     <language>en-us</language>
-    <lastBuildDate>Sun, 19 Jul 2026 04:00:00 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 23 Jul 2026 04:00:00 GMT</lastBuildDate>
     <atom:link href="${base}/feed.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Mental Health Is the New Theology of the West</title>
+      <link>${base}/briefing/mental-health-theology</link>
+      <guid isPermaLink="true">${base}/briefing/mental-health-theology</guid>
+      <pubDate>Thu, 23 Jul 2026 04:00:00 GMT</pubDate>
+      <description>A producer briefing on diagnostic reification, mental-health culture, and clinical reasoning.</description>
+    </item>
     <item>
       <title>AuDHD, Psychiatric Ontology, and the Difference Between Naming and Explaining</title>
       <link>${base}/writing/audhd-psychiatric-ontology</link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,8 +36,8 @@ export default function HomePage() {
               addiction treatment, and inpatient and outpatient settings. This site shares his writing on psychiatric language and clinical reasoning.
             </p>
             <div className="button-row">
-              <Link className="button primary" href="/writing/audhd-psychiatric-ontology">
-                Read the latest essay
+              <Link className="button primary" href="/briefing/mental-health-theology">
+                Read the latest briefing
               </Link>
               <Link className="button secondary" href="/professional-record">
                 Licensure
@@ -90,6 +90,24 @@ export default function HomePage() {
                 No invented testimonials, ratings, patient totals, media coverage, awards, or unsupported certification claims.
               </p>
             </article>
+          </div>
+        </div>
+      </section>
+
+      <section className="section-pad featured-writing">
+        <div className="shell feature-grid">
+          <div>
+            <p className="eyebrow">Producer briefing · July 23, 2026</p>
+            <h2>Mental Health Is the New Theology of the West</h2>
+          </div>
+          <div>
+            <p className="feature-deck">
+              A source-led producer briefing on diagnostic reification, commercialized mental-health language,
+              and the difference between describing distress and claiming to explain it.
+            </p>
+            <Link className="text-link" href="/briefing/mental-health-theology">
+              Read the producer briefing <span aria-hidden="true">→</span>
+            </Link>
           </div>
         </div>
       </section>

--- a/app/profiles-and-sources/page.tsx
+++ b/app/profiles-and-sources/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link"
 import Breadcrumbs from "@/components/breadcrumbs"
 import { createPageMetadata } from "@/lib/site-metadata"
 
@@ -43,6 +44,24 @@ export default function SourcesPage() {
 
       <section className="section-pad">
         <div className="shell">
+          <div className="section-heading compact">
+            <p className="eyebrow">Featured link</p>
+            <h2>Read the latest producer briefing.</h2>
+          </div>
+          <div className="link-card-grid">
+            <Link className="link-card" href="/briefing/mental-health-theology">
+              <span>
+                <strong>Mental Health Is the New Theology of the West</strong>
+                <small>Producer briefing · video, exhibits, and sources</small>
+              </span>
+              <span aria-hidden="true">→</span>
+            </Link>
+          </div>
+
+          <div className="section-heading compact">
+            <p className="eyebrow">Professional links</p>
+            <h2>Profiles and practice.</h2>
+          </div>
           <div className="link-card-grid">
             {profiles.map((profile) => (
               <a className="link-card" href={profile.href} key={profile.href} target="_blank" rel="noopener noreferrer">

--- a/app/writing/page.tsx
+++ b/app/writing/page.tsx
@@ -29,6 +29,41 @@ export default function WritingPage() {
           <article className="article-card featured-article-card">
             <Image
               className="article-card-graphic"
+              src="/mental-health-theology-og.png"
+              alt="Mental Health Is the New Theology of the West producer briefing"
+              width={1200}
+              height={630}
+              sizes="(max-width: 860px) 100vw, 42vw"
+            />
+            <div className="article-card-content">
+              <div className="article-meta">
+                <span>Producer briefing</span>
+                <time dateTime="2026-07-23">July 23, 2026</time>
+                <span>Video and source guide</span>
+              </div>
+              <h2>
+                <Link href="/briefing/mental-health-theology">
+                  Mental Health Is the New Theology of the West
+                </Link>
+              </h2>
+              <p>
+                A producer briefing that separates the reality of suffering from the claim that a diagnostic
+                label explains it, with exhibits, a captioned opening video, and linked source material.
+              </p>
+              <div className="tag-row" aria-label="Topics">
+                <span>Diagnostic reification</span>
+                <span>Mental-health culture</span>
+                <span>Clinical reasoning</span>
+              </div>
+              <Link className="text-link" href="/briefing/mental-health-theology">
+                Read the producer briefing <span aria-hidden="true">→</span>
+              </Link>
+            </div>
+          </article>
+
+          <article className="article-card featured-article-card">
+            <Image
+              className="article-card-graphic"
               src="/evidence-map.svg"
               alt="Diagram connecting observed facts, source records, classification, and independent evidence to a clinical question"
               width={960}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -9,6 +9,7 @@ const navigation = [
   { href: "/about", label: "About" },
   { href: "/professional-record", label: "Licensure" },
   { href: "/writing", label: "Writing" },
+  { href: "/briefing/mental-health-theology", label: "Briefing" },
   { href: "/profiles-and-sources", label: "Sources" },
   { href: "/contact", label: "Contact" },
 ]


### PR DESCRIPTION
### Motivation
- Make the producer briefing `briefing/mental-health-theology` discoverable from the main site navigation and link tree so visitors can reach the briefing from the homepage, writing index, and profiles list.
- Surface the briefing in the site feed and priority pages so it is included in syndication and search/indexing artifacts.
- Keep editorial presentation consistent by featuring the briefing with artwork and metadata alongside other writing on the site.

### Description
- Add a primary navigation entry for the briefing in `components/header.tsx` so the briefing appears in the main site menu (`/briefing/mental-health-theology`).
- Update the homepage `app/page.tsx` to make the primary CTA point to the briefing and add a homepage feature section promoting the producer briefing.
- Add a featured briefing card to the writing index in `app/writing/page.tsx` (uses `/mental-health-theology-og.png`, date, tags, and a link to the briefing). 
- Feature the briefing as the top internal link on the profiles-and-sources link tree by updating `app/profiles-and-sources/page.tsx` and adding the necessary `Link` import. 
- Publish the briefing through the RSS feed by adding an item and updating `lastBuildDate` in `app/feed.xml/route.ts`. 
- Record the new priority page in `README.md` under the site’s priority pages list.

### Testing
- Ran type checking and a production build with `npm run typecheck && npm run build`, which succeeded without TypeScript or build errors. 
- Started the local server (`next start`) and performed automated HTTP smoke checks that validated the presence of the briefing on `/`, `/writing`, `/profiles-and-sources`, and `/feed.xml`, all of which passed. 
- Confirmed the static route `/briefing/mental-health-theology` was generated during the build output, indicating the page is included in prerendered site routes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6372e3287c832e84af17d99d7c6e2d)